### PR TITLE
Fix urls generated for alternate geometries

### DIFF
--- a/src/mapzen.whosonfirst.uri.js
+++ b/src/mapzen.whosonfirst.uri.js
@@ -61,6 +61,7 @@ mapzen.whosonfirst.uri = (function(){
 		    ];
 
 		    if (args["alt"]) {
+			fname.push('alt');
 
 			if (args["source"]){
 


### PR DESCRIPTION
Previously, the 'alt' was being omitted. So instead of something like `2394839-alt-quattroshapes.geojson` the library was omitting `2394839-quattroshapes.geojson`.

Found this bug while preparing changes for whosonfirst/whosonfirst-www-spelunker#119, fixing this bug is necessary to address that issue.

@thisisaaronland This is the last of these small bug fixes, thanks for looking at them so quickly.